### PR TITLE
Removed config resetting stuff

### DIFF
--- a/src/main/java/com/shepherdjerred/sthorses/files/ConfigHelper.java
+++ b/src/main/java/com/shepherdjerred/sthorses/files/ConfigHelper.java
@@ -1,17 +1,12 @@
 package com.shepherdjerred.sthorses.files;
 
 import com.shepherdjerred.sthorses.Main;
-import org.bukkit.configuration.file.YamlConfiguration;
-
-import java.io.*;
 
 public class ConfigHelper {
 
     public static void loadConfigs() {
 
         Main.getInstance().saveDefaultConfig();
-        Main.getInstance().getConfig().setDefaults(YamlConfiguration.loadConfiguration(new File("config.yml")));
-        Main.getInstance().getConfig().options().copyDefaults(true);
         Main.getInstance().saveConfig();
 
         FileManager.getInstance().loadFiles();

--- a/src/main/java/com/shepherdjerred/sthorses/files/FileManager.java
+++ b/src/main/java/com/shepherdjerred/sthorses/files/FileManager.java
@@ -41,9 +41,6 @@ public class FileManager {
         try {
 
             messages.load(messagesFile);
-
-            messages.setDefaults(YamlConfiguration.loadConfiguration(new File("messages.yml")));
-            messages.options().copyDefaults(true);
             saveFiles(FileName.MESSAGES);
 
         } catch (Exception e) {


### PR DESCRIPTION
You should remove this stuff, because it keeps resetting your config files to default values.
It also make no sense of calling it multiple times in a row.

It is enough to use **saveDefaultConfig** (as of [API](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/plugin/java/JavaPlugin.html#saveDefaultConfig--) it does not override an existing config) for the default config and use **saveResource** for all other YAML files.

You used for your messages.yml an own [copy method](https://github.com/ShepherdJerred-minecraft/sthorses/blob/master/src/main/java/com/shepherdjerred/sthorses/files/FileManager.java#L35), that's ok, instead of **saveResource**.
